### PR TITLE
fix repositories.conf

### DIFF
--- a/cooker
+++ b/cooker
@@ -323,6 +323,7 @@ unpack_ib() {
            [ -d $output/ib ] && rm -rf $output/ib
            mv $output/lede-imagebuilder* $output/ib
            cp -f $output/ib/repositories.conf $output/ib/repositories.original.conf
+           sed -i 's%^src/gz .*_routing .*$%# &%' $output/ib/repositories.original.conf
        } || echo "-> Error installing ImageBuilder"
     }
 }

--- a/libremesh.repositories.conf
+++ b/libremesh.repositories.conf
@@ -2,5 +2,3 @@ src/gz libremesh http://repo.libremesh.org/lime-17.04/packages/{ARCH}/libremesh
 src/gz libremap http://repo.libremesh.org/lime-17.04/packages/{ARCH}/libremap
 src/gz limeui http://repo.libremesh.org/lime-17.04/packages/{ARCH}/limeui
 src/gz lm_routing http://repo.libremesh.org/lime-17.04/packages/{ARCH}/routing
-src/gz lm_base http://repo.libremesh.org/lime-17.04/packages/{ARCH}/base
-src/gz lm_packages http://repo.libremesh.org/lime-17.04/packages/{ARCH}/packages


### PR DESCRIPTION
We use our own (more up-to-date) build of the routing feed, disable
it in the original repositories.conf.
As we are using the upstream release in terms of core, base and
packages, do not add our locally built duplicates.

Alltogether this change makes sure that packages occur only once in
the list and hence that list is useful for the GSoC auto-updater.
Thanks to @aparcar for reporting this!