### PR TITLE
Adding explicitly lime-hwd-openwrt-wan to lime-basic based flavors

### DIFF
--- a/flavors.conf
+++ b/flavors.conf
@@ -1,6 +1,6 @@
 # Flavors
 lede_vanilla="luci-ssl"
 lime_default="lime-full -dnsmasq"
-lime_mini="lime-basic -opkg -wpad-mini hostapd-mini -kmod-usb-core -kmod-usb-ledtrig-usbport -kmod-usb2 -ppp -dnsmasq -ppp-mod-pppoe -6relayd -odhcp6c -odhcpd -iptables -ip6tables"
-lime_zero="lime-basic-no-ui -wpad-mini hostapd-mini -ppp -dnsmasq -ppp-mod-pppoe -6relayd -odhcp6c -odhcpd -iptables -ip6tables"
+lime_mini="lime-basic -opkg -wpad-mini hostapd-mini -kmod-usb-core -kmod-usb-ledtrig-usbport -kmod-usb2 -ppp -dnsmasq -ppp-mod-pppoe -6relayd -odhcp6c -odhcpd -iptables -ip6tables lime-hwd-openwrt-wan"
+lime_zero="lime-basic-no-ui -wpad-mini hostapd-mini -ppp -dnsmasq -ppp-mod-pppoe -6relayd -odhcp6c -odhcpd -iptables -ip6tables lime-hwd-openwrt-wan"
 lime_newui_test="lime-full lime-webui-ng-luci -dnsmasq"


### PR DESCRIPTION
Needs to be merged at the same time of libremesh/lime-packages#200 for fixing libremesh/lime-packages#175