### PR TITLE
Allows to evaluate options after --update-feeds. Fixes #27

### DIFF
--- a/cooker
+++ b/cooker
@@ -480,7 +480,7 @@ while true; do
         ;;
         --update-feeds)
             update_feeds
-            break
+            shift
         ;;
         --no-update)
             no_update=1


### PR DESCRIPTION
Changes `break` with `shift` allowing one to specify other options after --update-feeds