### PR TITLE
Add profile packages to repo

### DIFF
--- a/libremesh.repositories.conf
+++ b/libremesh.repositories.conf
@@ -2,3 +2,4 @@ src/gz libremesh http://repo.libremesh.org/current/packages/{ARCH}/libremesh
 src/gz libremap http://repo.libremesh.org/current/packages/{ARCH}/libremap
 src/gz limeui http://repo.libremesh.org/current/packages/{ARCH}/limeui
 src/gz lm_routing http://repo.libremesh.org/current/packages/{ARCH}/routing
+src/gz lm_profiles http://repo.libremesh.org/network-profiles/


### PR DESCRIPTION
This could eventually solve a couple of dependency and versioning problems.
Future installations could install these packages instead of using network-profiles via a folder.