### PR TITLE
introduce mt76x8 target

### DIFF
--- a/targets.list
+++ b/targets.list
@@ -3,8 +3,7 @@ ramips/rt305x
 ramips/rt3883
 ramips/mt7620
 ramips/mt7621
-ramips/mt7628
-ramips/mt7688
+ramips/mt76x8
 lantiq/xrx200
 lantiq/xway
 x86/generic


### PR DESCRIPTION
mt7688 and mt7628 been merged

Signed-off-by: Paul Spooren <paul@spooren.de>