### PR TITLE
Adding ability to specify branch or commit to use for the community n…

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ The default way to create or use a community is to use this Git repository https
 
 `/<community name>/<device profile name>/<files and directories>`
 
+You can choose to use a specific branch/commit of the network-profiles repo by appending ;<branch name> or ^<commit id> to the communities_git in your local version of options.conf, by default it will use the repos default branch (usually master) ie: 'https://github.com/libremesh/network-profiles;testing-branch' 
+
 Both community and device profile names can be any of your choice (must exist!) , since they are only used for identifying it. When executing a cook order, you can specify the community profile like this:
 
 `./cooker -c ar71xx/generic --profile=tl-wdr4300-v1 --flavor=lime_default --community=CommunityName/ProfileName`

--- a/cooker
+++ b/cooker
@@ -297,12 +297,23 @@ download_feeds() {
 }
 
 download_communities() {
-    [ ! -d "$communities_dir" ] && {
+    [ ! -d "$communities_git" ] && {
         echo "-> Downloading communities repository"
-        git clone $communities_git $communities_dir || {
+        if echo "$communities_git" | grep \;; then
+            url="$(echo $communities_git | awk -F\; '{print $1}')"
+            branch="$(echo $communities_git | awk -F\; '{print $2}')"
+            git clone $url -b $branch $communities_dir
+        elif echo "$communities_git" | grep \^; then
+            url="$(echo $communities_git | awk -F\^ '{print $1}')"
+            commit="$(echo $communities_git | awk -F\^ '{print $2}')"
+            git clone $url $communities_dir
+            ( cd $communities_dir && git checkout $commit )
+        else
+            git clone $communities_git $communities_dir || {
             echo "-> Cannot fetch communities repository"
             exit 1
         }
+        fi
     }
 }
 

--- a/options.conf
+++ b/options.conf
@@ -1,6 +1,6 @@
 release=17.01.4
 base_url=https://downloads.lede-project.org/releases/$release/targets/
-communities_git=https://github.com/libremesh/network-profiles.git
+communities_git='https://github.com/libremesh/network-profiles.git'
 communities_dir=communities
 tmp_dir=tmp
 feeds_default_file=feeds.conf.default


### PR DESCRIPTION
…etworks.

Helps to be able to specify a commit or branch to groups that are doing community managed builds
