### PR TITLE
cooker: add sdk_compile_repo option

### DIFF
--- a/cooker
+++ b/cooker
@@ -219,6 +219,13 @@ build_sdk() {
     }
 
     cp ${sdk_config}.local $sdk/.config 2>/dev/null || cp ${sdk_config} $sdk/.config
+
+    for r in $sdk_compile_repos; do
+        (cd $sdk && \
+            scripts/feeds uninstall -p $r && \
+            scripts/feeds install -a -p $r -d m)
+    done
+
     make -C $sdk defconfig
     make -j$J -C $sdk V=$V && [ -z "$no_link_ib" ] && {
         [ -f "$ib/repositories.original.conf" ] || download_ib $target

--- a/options.conf
+++ b/options.conf
@@ -26,6 +26,7 @@ sdk_install_packages="libustream-openssl firewall luci-app-bmx7"
 # repositories to install
 sdk_install_repos="libremesh libremap limeui"
 # remote package repositories use for --remote
+sdk_compile_repos=""
 remote_pkg_repos="libremesh.repositories.conf"
 # default flavor when images are cooked
 default_flavor="lime_default"


### PR DESCRIPTION
the new option compiles all packages as the given repo. This simplifies
usage in a CLI system while still honoring libremesh.sdk.config.