### PR TITLE
follow up on #60

### DIFF
--- a/snippets/create_repository.sh
+++ b/snippets/create_repository.sh
@@ -6,11 +6,9 @@ echo "-> Output directory: $OUTDIR"
 for link in $OUTDIR/*; do
   unlink $link 2>/dev/null
 done
-for target in $(cat $targets_list); do
-  for arch in $release/$target/sdk/bin/packages/*; do
-    [ -d "$arch" ] && {
-      echo "-> Creating symlink for $arch"
-      ln -s $PWD/$arch $OUTDIR/ 2>/dev/null
-    }
-  done
+for arch in $release/*/*/sdk/bin/packages/*; do
+  [ -d "$arch" ] && {
+    echo "-> Creating symlink for $arch"
+    ln -s $PWD/$arch $OUTDIR/ 2>/dev/null
+  }
 done


### PR DESCRIPTION
Independent of the set targets all repositories build are created.
This is useful for CI and when you use cooker for non standard targets.