### PR TITLE
Update flavors.conf

### DIFF
--- a/flavors.conf
+++ b/flavors.conf
@@ -1,7 +1,7 @@
 # Flavors
 lede_vanilla="luci-ssl"
-lime_default="lime-full lime-app -dnsmasq"
-lime_mini="lime-basic -opkg -wpad-mini hostapd-mini -kmod-usb-core -kmod-usb-ledtrig-usbport -kmod-usb2 -ppp -dnsmasq -ppp-mod-pppoe -6relayd -odhcp6c -odhcpd -iptables -ip6tables"
-lime_zero="lime-basic-no-ui -wpad-mini hostapd-mini -ppp -dnsmasq -ppp-mod-pppoe -6relayd -odhcp6c -odhcpd -iptables -ip6tables"
-lime_newui_test="lime-full lime-app -dnsmasq"
-lime_babel="-dnsmasq dnsmasq-distributed-hosts dnsmasq-lease-share lime-app lime-debug lime-docs lime-hwd-ground-routing lime-hwd-openwrt-wan lime-map-agent lime-proto-anygw lime-proto-babeld lime-proto-batadv lime-system lime-webui luci"
+lime_default="lime-full lime-app"
+lime_mini="lime-basic -opkg -wpad-mini hostapd-mini -kmod-usb-core -kmod-usb-ledtrig-usbport -kmod-usb2 -ppp -ppp-mod-pppoe -6relayd -odhcp6c -iptables -ip6tables"
+lime_zero="lime-basic-no-ui -wpad-mini hostapd-mini -ppp -ppp-mod-pppoe -6relayd -odhcp6c -iptables -ip6tables"
+lime_newui_test="lime-full lime-app"
+lime_babel="dnsmasq-lease-share lime-app lime-debug lime-docs lime-hwd-ground-routing lime-hwd-openwrt-wan lime-map-agent lime-proto-anygw lime-proto-babeld lime-proto-batadv lime-system lime-webui luci"


### PR DESCRIPTION
Due to https://github.com/libremesh/lime-packages/pull/379 it's no longer required to remove dnsmasq.
odhcpd is never automatically installed, instead it's smaller version called odhcpd-ipv6only