### PR TITLE
docker: added dot ignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+17.01.4
+18.06.1
+dl
+feeds
+output
+tmp


### PR DESCRIPTION
## docker build context
```
## go1.11.1
go get -v -u github.com/pwaller/docker-show-context
```


## before
```
Scanning local directory (in tar / on disk):
  286823 / 286824 (9638 / 9745 MiB) (11.0s elapsed) .. completed

Excluded by .dockerignore: 1 files totalling 106.36 MiB

Final .tar:
  286823 files totalling 9638.16 MiB (+ 199.13 MiB tar overhead)
  Took 11.04 seconds to build

Top 10 directories by time spent:
 1499 ms: tmp
  307 ms: 18.06.1/ar71xx/generic/ib/build_dir/target-mips_24kc_musl/linux-ar71xx_generic/tmp
   91 ms: 18.06.1/ar71xx/generic/ib/build_dir/target-mips_24kc_musl/linux-ar71xx_generic
   75 ms: 17.01.4/ar71xx/generic/ib/build_dir/target-mips_24kc_musl-1.1.16/linux-ar71xx_generic
   70 ms: feeds/base/target/linux/layerscape/patches-4.9
   67 ms: 18.06.1/ar71xx/generic/sdk/build_dir/target-mips_24kc_musl/linux-ar71xx_generic/packages/.pkgdir
   65 ms: 18.06.1/brcm2708/bcm2710/ib/build_dir/target-aarch64_cortex-a53_musl/linux-brcm2708_bcm2710
   56 ms: 18.06.1/brcm2708/bcm2710/sdk/build_dir/target-aarch64_cortex-a53_musl/linux-brcm2708_bcm2710/packages/.pkgdir
   50 ms: dl
   46 ms: feeds/base/.git

Top 10 directories by storage:
 988.65 MiB: 18.06.1/ar71xx/generic/ib/build_dir/target-mips_24kc_musl/linux-ar71xx_generic/tmp
 738.25 MiB: tmp
 286.01 MiB: 18.06.1/brcm2708/bcm2710/ib/build_dir/target-aarch64_cortex-a53_musl/linux-brcm2708_bcm2710
 268.31 MiB: 18.06.1/ar71xx/generic/ib/build_dir/target-mips_24kc_musl/linux-ar71xx_generic
 228.29 MiB: 17.01.4/ar71xx/generic/ib/build_dir/target-mips_24kc_musl-1.1.16/linux-ar71xx_generic
 158.92 MiB: dl
 151.54 MiB: feeds/base/.git/objects/pack
 118.66 MiB: 18.06.1/brcm2708/bcm2710/ib/build_dir/target-aarch64_cortex-a53_musl/linux-brcm2708_bcm2710/tmp
  75.15 MiB: 17.01.4/ar71xx/generic/sdk/build_dir/target-mips_24kc_musl-1.1.16/linux-firmware-2016-09-21-42ad5367
  75.15 MiB: 17.01.4/x86/64/sdk/build_dir/target-x86_64_musl-1.1.16/linux-firmware-2016-09-21-42ad5367

Top 10 directories by file count:
 1182: 17.01.4/x86/64/ib/build_dir/target-x86_64_musl-1.1.16/root-x86/usr/lib/opkg/info
 1150: 18.06.1/ar71xx/generic/sdk/build_dir/target-mips_24kc_musl/linux-ar71xx_generic/linux-4.9.120/include/linux
 1147: 18.06.1/brcm2708/bcm2710/sdk/build_dir/target-aarch64_cortex-a53_musl/linux-brcm2708_bcm2710/linux-4.9.120/include/linux
 1119: 17.01.4/ar71xx/generic/sdk/build_dir/target-mips_24kc_musl-1.1.16/linux-ar71xx_generic/linux-4.4.92/include/linux
 1116: 17.01.4/x86/64/sdk/build_dir/target-x86_64_musl-1.1.16/linux-x86_64/linux-4.4.92/include/linux
  949: 17.01.4/x86/64/sdk/staging_dir/target-x86_64_musl-1.1.16/pkginfo
  948: 18.06.1/ar71xx/generic/sdk/staging_dir/target-mips_24kc_musl/root-ar71xx/lib/modules/4.9.120
  943: 18.06.1/ar71xx/generic/sdk/staging_dir/target-mips_24kc_musl/pkginfo
  924: 17.01.4/ar71xx/generic/sdk/staging_dir/target-mips_24kc_musl-1.1.16/pkginfo
  886: 17.01.4/ar71xx/generic/sdk/staging_dir/target-mips_24kc_musl-1.1.16/root-ar71xx/lib/modules/4.4.92

Top 10 file extensions by storage:
3330.50 MiB: .bin
 840.81 MiB: .xz
 747.95 MiB: .elf
 497.39 MiB: .squashfs
 457.77 MiB: 
 386.66 MiB: .o
 356.61 MiB: .ko
 256.00 MiB: .ext4
 254.82 MiB: .h
 250.27 MiB: .a
```
 

## after

```

Scanning local directory (in tar / on disk):
  645 / 286824 (2 / 9745 MiB) (0.0s elapsed) .. completed

Excluded by .dockerignore: 286179 files totalling 9742.26 MiB

Final .tar:
  645 files totalling 2.27 MiB (+ 0.43 MiB tar overhead)
  Took 0.01 seconds to build

Top 10 directories by time spent:
    0 ms: .
    0 ms: communities/NonoLibre/comun/usr/sbin
    0 ms: communities/labolsa.libre.org.ar/comun/etc/config
    0 ms: communities/.git
    0 ms: communities/fuma-aonline/fumacaonline-1607/usr/bin
    0 ms: communities/sbmesh/common
    0 ms: communities/libremesh/encrypt-11s+ap
    0 ms: communities/nono.libre.org.ar/comun/usr/sbin
    0 ms: communities/klimacamp/secure/usr/sbin
    0 ms: communities/EspaiVeinal/Comu/etc/config

Top 10 directories by storage:
   0.45 MiB: communities/.git/objects/pack
   0.29 MiB: communities/klimacamp/secure/usr/bin
   0.29 MiB: communities/quintanalibre.org.ar/librerouter/usr/bin
   0.29 MiB: communities/NonoLibre/comun/usr/bin
   0.29 MiB: communities/klimacamp/common/usr/bin
   0.29 MiB: communities/nono.libre.org.ar/comun/usr/bin
   0.10 MiB: .
   0.04 MiB: communities/.git
   0.01 MiB: communities/.git/hooks
   0.01 MiB: communities/openNET.io/1144-W2PA-LIME-XXXX/etc/uci-defaults

Top 10 directories by file count:
   20: .
   15: communities/NonoLibre/comun/etc/uci-defaults
   13: communities/nono.libre.org.ar/comun/etc/uci-defaults
   13: communities/quintanalibre.org.ar/librerouter/etc/uci-defaults
   12: communities/quintanalibre.org.ar/comun/etc/uci-defaults
   11: communities/.git/hooks
   11: communities/labolsa.libre.org.ar/comun/etc/uci-defaults
   11: communities/laserranita.libre.org.ar/comun/etc/uci-defaults
    9: communities/openNET.io/1144-W2PA-LIME-XXXX/etc/uci-defaults
    9: communities/moinho/comun/etc/uci-defaults

Top 10 file extensions by storage:
   1.74 MiB: 
   0.40 MiB: .pack
   0.04 MiB: .idx
   0.02 MiB: .md
   0.01 MiB: .sh
   0.01 MiB: .sample
   0.01 MiB: .log
   0.01 MiB: .conf
   0.00 MiB: .png
   0.00 MiB: .adoc
```