### PR TITLE
s/lede-project/openwrt/ in options.conf

### DIFF
--- a/options.conf
+++ b/options.conf
@@ -1,5 +1,5 @@
 release=17.01.4
-base_url=https://downloads.lede-project.org/releases/$release/targets/
+base_url=https://downloads.openwrt.org/releases/$release/targets/
 communities_git=https://github.com/libremesh/network-profiles.git
 communities_dir=communities
 tmp_dir=tmp


### PR DESCRIPTION
This change is completely equivalent, in fact, lede-project.org is doing a 301 HTTP (redirection)

This will help moving to the next releases (that are openwrt, and not lede anymore)